### PR TITLE
Storing Users, Refactoring BlueskyService, Adding DynamicConfigs

### DIFF
--- a/src/main/kotlin/dev/raphaeldelio/model/Profile.kt
+++ b/src/main/kotlin/dev/raphaeldelio/model/Profile.kt
@@ -1,0 +1,115 @@
+package dev.raphaeldelio.model
+
+data class Profile(
+    val did: String?,
+    val handle: String?,
+    val displayName: String?,
+    val description: String?,
+    val avatar: String?,
+    val banner: String?,
+    val followersCount: Int?,
+    val followsCount: Int?,
+    val postsCount: Int?,
+    val associated: Associated?,
+    val joinedViaStarterPack: JoinedViaStarterPack?,
+    val indexedAt: String?,
+    val createdAt: String?,
+    val viewer: Viewer?,
+    val labels: List<Label>?,
+    val pinnedPost: PinnedPost?
+) {
+    data class Associated(
+        val lists: Int?,
+        val feedgens: Int?,
+        val starterPacks: Int?,
+        val labeler: Boolean?,
+        val chat: Chat?
+    ) {
+        data class Chat(
+            val allowIncoming: String?
+        )
+    }
+
+    data class JoinedViaStarterPack(
+        val uri: String?,
+        val cid: String?,
+        val record: Map<String?, Any>, // Generic map for unstructured data
+        val creator: Creator?,
+        val listItemCount: Int?,
+        val joinedWeekCount: Int?,
+        val joinedAllTimeCount: Int?,
+        val labels: List<Label>,
+        val indexedAt: String
+    ) {
+        data class Creator(
+            val did: String?,
+            val handle: String?,
+            val displayName: String?,
+            val avatar: String?,
+            val associated: Associated?,
+            val viewer: Viewer?,
+            val labels: List<Label>?,
+            val createdAt: String?
+        )
+    }
+
+    data class Viewer(
+        val muted: Boolean?,
+        val mutedByList: ViewerList?,
+        val blockedBy: Boolean?,
+        val blocking: String?,
+        val blockingByList: ViewerList?,
+        val following: String?,
+        val followedBy: String?,
+        val knownFollowers: KnownFollowers?
+    ) {
+        data class ViewerList(
+            val uri: String?,
+            val cid: String?,
+            val name: String?,
+            val purpose: String?,
+            val avatar: String?,
+            val listItemCount: Int?,
+            val labels: List<Label>?,
+            val viewer: ViewerState?,
+            val indexedAt: String?
+        ) {
+            data class ViewerState(
+                val muted: Boolean?,
+                val blocked: String?
+            )
+        }
+
+        data class KnownFollowers(
+            val count: Int?,
+            val followers: List<Follower?>
+        ) {
+            data class Follower(
+                val did: String?,
+                val handle: String?,
+                val displayName: String?,
+                val avatar: String?,
+                val associated: Associated?,
+                val labels: List<Label>?,
+                val createdAt: String?
+            )
+        }
+    }
+
+    data class Label(
+        val ver: Int?,
+        val src: String?,
+        val uri: String?,
+        val cid: String?,
+        val `val`: String?,
+        val neg: Boolean?,
+        val cts: String?,
+        val exp: String?,
+        val sig: String?
+    )
+
+    data class PinnedPost(
+        val uri: String?,
+        val cid: String?
+    )
+}

--- a/src/main/kotlin/dev/raphaeldelio/service/AuthenticationService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/AuthenticationService.kt
@@ -1,0 +1,41 @@
+package dev.raphaeldelio.service
+
+import dev.raphaeldelio.Logger
+import dev.raphaeldelio.model.*
+import org.http4k.client.ApacheClient
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.format.Jackson
+
+class AuthenticationService(
+    blueskyConfig: BlueskyConfig,
+    private val redisService: RedisService
+) {
+    private val client = ApacheClient()
+    private val apiUrl = blueskyConfig.apiurl
+    private val username = blueskyConfig.username
+    private val password = blueskyConfig.password
+
+    private fun sendRequest(request: Request): Response {
+        return client(request)
+    }
+
+    fun getAccessToken(): String {
+        val request = Request(Method.POST, "$apiUrl/com.atproto.server.createSession")
+            .header("Content-Type", "application/json")
+            .body(Jackson.asFormatString(mapOf("identifier" to username, "password" to password)))
+
+        val response = sendRequest(request)
+        return if (response.status == Status.OK) {
+            val result = Jackson.asA(response.bodyString(), LoginResponse::class)
+            redisService.set("did", result.did)
+            Logger.info("✅ Login successful. DID: ${result.did}")
+            result.accessJwt
+        } else {
+            Logger.info("⚠️ Authentication failed: ${response.status}")
+            ""
+        }
+    }
+}

--- a/src/main/kotlin/dev/raphaeldelio/service/DynamicConfigService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/DynamicConfigService.kt
@@ -2,11 +2,15 @@ package dev.raphaeldelio.service
 
 class DynamicConfigService(private val redisService: RedisService) {
 
+    companion object {
+        private const val PREFIX = "config:"
+    }
+
     fun getVersion(): String {
-        return redisService.get("version") ?: "0.1.0"
+        return redisService.get("${PREFIX}version") ?: "0.1.0"
     }
 
     fun setVersion(version: String) {
-        redisService.set("version", version)
+        redisService.set("${PREFIX}version", version)
     }
 }

--- a/src/main/kotlin/dev/raphaeldelio/service/DynamicConfigService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/DynamicConfigService.kt
@@ -1,0 +1,12 @@
+package dev.raphaeldelio.service
+
+class DynamicConfigService(private val redisService: RedisService) {
+
+    fun getVersion(): String {
+        return redisService.get("version") ?: "0.1.0"
+    }
+
+    fun setVersion(version: String) {
+        redisService.set("version", version)
+    }
+}

--- a/src/main/kotlin/dev/raphaeldelio/service/MigrationService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/MigrationService.kt
@@ -8,7 +8,7 @@ class MigrationService(
 ) {
 
     companion object {
-        private val LATEST_VERSION = "0.2.0"
+        private const val LATEST_VERSION = "0.2.0"
     }
 
     fun migrate(token: String) {

--- a/src/main/kotlin/dev/raphaeldelio/service/MigrationService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/MigrationService.kt
@@ -1,0 +1,44 @@
+package dev.raphaeldelio.service
+
+import dev.raphaeldelio.Logger
+
+class MigrationService(
+    private val userService: UserService,
+    private val dynamicConfigService: DynamicConfigService
+) {
+
+    companion object {
+        private val LATEST_VERSION = "0.2.0"
+    }
+
+    fun migrate(token: String) {
+        if (dynamicConfigService.getVersion() == LATEST_VERSION) {
+            Logger.info("🎉 Migration not needed. Already on latest version: $LATEST_VERSION")
+            return
+        }
+
+        val version = dynamicConfigService.getVersion()
+        Logger.info("🚀 Starting migration from version: $version")
+
+        when (version) {
+            "0.1.0" -> migrateUsers(token)
+            else -> Logger.info("🎉 No migration needed")
+        }
+
+        dynamicConfigService.setVersion(LATEST_VERSION)
+        Logger.info("🎉 Migration completed. Version: 0.2.0")
+    }
+
+    /**
+     * Version: 0.1.0 -> 0.2.0
+     * Fetch profiles for all followed authors and store them in Redis
+     */
+    fun migrateUsers(token: String) {
+        val followedAuthors = userService.getAllFollowedUsers()
+        Logger.info("🚚 Migrating ${followedAuthors.size} followed authors")
+
+        followedAuthors.forEach { authorDid ->
+            userService.getProfile(token, authorDid)
+        }
+    }
+}

--- a/src/main/kotlin/dev/raphaeldelio/service/RedisService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/RedisService.kt
@@ -23,16 +23,20 @@ class RedisService(private val jedisPooled: JedisPooled) {
         return jedisPooled.sismember(key, value)
     }
 
-    fun setJson(key: String, json: Any) {
+    fun setGetAll(key: String): Set<String> {
+        return jedisPooled.smembers(key)
+    }
+
+    fun jsonSet(key: String, json: Any) {
         jedisPooled.jsonSet(key, Jackson.asFormatString(json))
     }
 
-    fun getJson(key: String): Any? {
+    fun jsonGet(key: String): Any? {
         return jedisPooled.jsonGet(key) ?: return null
     }
 
-    inline fun <reified T: Any> getJsonAs(key: String): T? {
-        val json = getJson(key) ?: return null
+    inline fun <reified T: Any> jsonGetAs(key: String): T? {
+        val json = jsonGet(key) ?: return null
         return Jackson.asA<T>(Jackson.asFormatString(json))
     }
 }

--- a/src/main/kotlin/dev/raphaeldelio/service/RedisService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/RedisService.kt
@@ -1,32 +1,38 @@
 package dev.raphaeldelio.service
 
-import redis.clients.jedis.JedisPool
+import org.http4k.format.Jackson
+import redis.clients.jedis.JedisPooled
 
-class RedisService(private val jedisPool: JedisPool) {
+class RedisService(private val jedisPooled: JedisPooled) {
     fun get(key: String): String? {
-        jedisPool.resource.use { jedis ->
-            return jedis.get(key)
-        }
+        return jedisPooled.get(key)
     }
 
     fun set(key: String, value: String, expireSeconds: Long? = null) {
-        jedisPool.resource.use { jedis ->
-            jedis.set(key, value)
-            if (expireSeconds != null) {
-                jedis.expire(key, expireSeconds)
-            }
+        jedisPooled.set(key, value)
+        if (expireSeconds != null) {
+            jedisPooled.expire(key, expireSeconds)
         }
     }
 
     fun setAdd(key: String, value: String) {
-        jedisPool.resource.use { jedis ->
-            jedis.sadd(key, value)
-        }
+        jedisPooled.sadd(key, value)
     }
 
     fun setContains(key: String, value: String): Boolean {
-        jedisPool.resource.use { jedis ->
-            return jedis.sismember(key, value)
-        }
+        return jedisPooled.sismember(key, value)
+    }
+
+    fun setJson(key: String, json: Any) {
+        jedisPooled.jsonSet(key, Jackson.asFormatString(json))
+    }
+
+    fun getJson(key: String): Any? {
+        return jedisPooled.jsonGet(key) ?: return null
+    }
+
+    inline fun <reified T: Any> getJsonAs(key: String): T? {
+        val json = getJson(key) ?: return null
+        return Jackson.asA<T>(Jackson.asFormatString(json))
     }
 }

--- a/src/main/kotlin/dev/raphaeldelio/service/UserService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/UserService.kt
@@ -1,0 +1,88 @@
+package dev.raphaeldelio.service
+
+import dev.raphaeldelio.Logger
+import dev.raphaeldelio.model.*
+import org.http4k.client.ApacheClient
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Status
+import org.http4k.format.Jackson
+
+class UserService(
+    blueskyConfig: BlueskyConfig,
+    private val redisService: RedisService
+) {
+    private val client = ApacheClient()
+    private val apiUrl = blueskyConfig.apiurl
+
+    fun followUser(token: String, authorDid: String) {
+        handleUserAction(
+            token = token,
+            actionKey = "followedAuthors",
+            uniqueId = authorDid,
+            data = FollowData(
+                repo = redisService.get("did") ?: throw IllegalArgumentException("DID not found in Redis"),
+                record = FollowRecord(subject = authorDid)
+            ),
+            actionName = "follow",
+            collection = "com.atproto.repo.createRecord"
+        )
+    }
+
+    fun getProfile(token: String, did: String): Profile {
+        val cacheKey = "profile:$did"
+        // Check if the profile is already in Redis
+        val cachedProfile = redisService.getJsonAs<Profile>(cacheKey)
+        if (cachedProfile != null) {
+            Logger.info("ℹ️ Profile for DID: $did retrieved from Redis cache")
+            return cachedProfile
+        }
+
+        // Fetch the profile from the API if not in cache
+        val request = Request(Method.GET, "$apiUrl/app.bsky.actor.getProfile/")
+            .header("Authorization", "Bearer $token")
+            .query("actor", did)
+
+        val response = client(request)
+        if (response.status == Status.OK) {
+            Logger.info("✅ Successfully retrieved profile for DID: $did")
+
+            val profile = Jackson.asA(response.bodyString(), Profile::class)
+            redisService.setJson(cacheKey, profile)
+            Logger.info("🗄️ Profile for DID: $did stored in Redis")
+
+            return profile
+        } else {
+            val errorMessage = "⚠️ Failed to retrieve profile for DID: $did. Error: ${response.bodyString()}"
+            Logger.error(errorMessage)
+            throw IllegalStateException(errorMessage)
+        }
+    }
+
+    private fun handleUserAction(
+        token: String,
+        actionKey: String,
+        uniqueId: String,
+        data: Any,
+        actionName: String,
+        collection: String
+    ) {
+        if (redisService.setContains(actionKey, uniqueId)) {
+            Logger.info("🔁 Already ${actionName}ed: $uniqueId. Skipping.")
+            return
+        }
+
+        val request = Request(Method.POST, "$apiUrl/$collection")
+            .header("Authorization", "Bearer $token")
+            .header("Content-Type", "application/json")
+            .body(Jackson.asFormatString(data))
+
+        val response = client(request)
+        if (response.status == Status.OK) {
+            Logger.info("✅ Successfully ${actionName}ed: $uniqueId")
+            redisService.setAdd(actionKey, uniqueId)
+        } else {
+            Logger.info("⚠️ Failed to ${actionName}: $uniqueId. Error: ${response.bodyString()}")
+        }
+    }
+}

--- a/src/test/kotlin/dev/raphaeldelio/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/dev/raphaeldelio/service/AuthenticationServiceTest.kt
@@ -1,0 +1,55 @@
+package dev.raphaeldelio.service
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import dev.raphaeldelio.model.BlueskyConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.http4k.format.Jackson
+import org.junit.jupiter.api.Test
+
+class AuthenticationServiceTest : BaseTest() {
+
+    private fun createBlueskyService(): AuthenticationService {
+        val redisService = createRedisService()
+        val blueskyConfig = BlueskyConfig(
+            apiurl = getWireMockBaseUrl(),
+            username = "test-user",
+            password = "test-password"
+        )
+        return AuthenticationService(blueskyConfig, redisService)
+    }
+
+    private fun stubAuthenticationResponse() {
+        wireMockServer.stubFor(
+            post(urlEqualTo("/com.atproto.server.createSession"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withBody(Jackson.asFormatString(mapOf(
+                            "accessJwt" to "test-access-token",
+                            "refreshJwt" to "test-refresh-token",
+                            "handle" to "example.handle",
+                            "did" to "did:example:123",
+                            "email" to "user@example.com",
+                            "emailConfirmed" to true,
+                            "active" to true,
+                            "status" to "active"
+                        )))
+                )
+        )
+    }
+
+    @Test
+    fun `should authenticate and get access token with detailed response`() {
+        // Arrange
+        stubAuthenticationResponse()
+        val blueskyService = createBlueskyService()
+
+        // Act
+        val accessToken = blueskyService.getAccessToken()
+
+        // Assert
+        assertThat(accessToken).isEqualTo("test-access-token")
+        val redisService = createRedisService()
+        assertThat(redisService.get("did")).isEqualTo("did:example:123")
+    }
+}

--- a/src/test/kotlin/dev/raphaeldelio/service/BaseTest.kt
+++ b/src/test/kotlin/dev/raphaeldelio/service/BaseTest.kt
@@ -7,6 +7,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import redis.clients.jedis.JedisPooled
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class BaseTest {
@@ -16,7 +17,7 @@ abstract class BaseTest {
     @BeforeEach
     fun setUp() {
         // Start Redis container
-        redisContainer = GenericContainer(DockerImageName.parse("redis:alpine"))
+        redisContainer = GenericContainer(DockerImageName.parse("redis:8.0-M02-alpine"))
             .withExposedPorts(6379)
         redisContainer.start()
 
@@ -34,4 +35,9 @@ abstract class BaseTest {
     protected fun getRedisHost(): String = redisContainer.host
     protected fun getRedisPort(): Int = redisContainer.getMappedPort(6379)
     protected fun getWireMockBaseUrl(): String = wireMockServer.baseUrl()
+
+    fun createRedisService(): RedisService {
+        val jedisPooled = JedisPooled(getRedisHost(), getRedisPort())
+        return RedisService(jedisPooled)
+    }
 }

--- a/src/test/kotlin/dev/raphaeldelio/service/UserServiceTest.kt
+++ b/src/test/kotlin/dev/raphaeldelio/service/UserServiceTest.kt
@@ -60,12 +60,12 @@ class UserServiceTest : BaseTest() {
     }
 
     @Test
-    fun `should fetch profile from Redis cache when available`() {
+    fun `should fetch profile from Redis when available`() {
         // Arrange
         val did = "did:example:123"
-        val expectedProfile = createTestProfile(did, handle = "cached-handle", displayName = "Cached User")
+        val expectedProfile = createTestProfile(did, handle = "stored-handle", displayName = "Stored User")
         val redisService = createRedisService()
-        cacheProfileInRedis(redisService, did, expectedProfile)
+        storeProfileInRedis(redisService, did, expectedProfile)
 
         val userService = createUserService()
 
@@ -127,8 +127,8 @@ class UserServiceTest : BaseTest() {
         )
     }
 
-    private fun cacheProfileInRedis(redisService: RedisService, did: String, profile: Profile) {
-        redisService.setJson("profile:$did", profile)
+    private fun storeProfileInRedis(redisService: RedisService, did: String, profile: Profile) {
+        redisService.jsonSet("profile:$did", profile)
     }
 
     private fun verifyProfile(actual: Profile, expected: Profile) {
@@ -136,9 +136,9 @@ class UserServiceTest : BaseTest() {
     }
 
     private fun verifyProfileInRedis(redisService: RedisService, did: String, expected: Profile) {
-        val cachedProfile = redisService.getJsonAs<Profile>("profile:$did")
-        assertThat(cachedProfile).isNotNull
-        assertThat(Jackson.asFormatString(cachedProfile!!)).isEqualTo(Jackson.asFormatString(expected))
+        val storedProfile = redisService.jsonGetAs<Profile>("profile:$did")
+        assertThat(storedProfile).isNotNull
+        assertThat(Jackson.asFormatString(storedProfile!!)).isEqualTo(Jackson.asFormatString(expected))
     }
 
     private fun verifyApiPost(endpoint: String, token: String, bodyChecks: Map<String, String>) {

--- a/src/test/kotlin/dev/raphaeldelio/service/UserServiceTest.kt
+++ b/src/test/kotlin/dev/raphaeldelio/service/UserServiceTest.kt
@@ -1,0 +1,159 @@
+package dev.raphaeldelio.service
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import dev.raphaeldelio.model.BlueskyConfig
+import dev.raphaeldelio.model.Profile
+import org.assertj.core.api.Assertions.assertThat
+import org.http4k.format.Jackson
+import org.junit.jupiter.api.Test
+
+class UserServiceTest : BaseTest() {
+
+    private fun createUserService(): UserService {
+        val redisService = createRedisService()
+        val blueskyConfig = BlueskyConfig(
+            apiurl = getWireMockBaseUrl(),
+            username = "test-user",
+            password = "test-password"
+        )
+        return UserService(blueskyConfig, redisService)
+    }
+
+    @Test
+    fun `should follow a user and add to Redis`() {
+        // Arrange
+        val authorDid = "did:example:123"
+        val token = "test-access-token"
+        stubApiPost("/com.atproto.repo.createRecord", mapOf("success" to true))
+
+        val userService = createUserService()
+        val redisService = createRedisService()
+        redisService.set("did", authorDid)
+
+        // Act
+        userService.followUser(token, authorDid)
+
+        // Assert
+        assertThat(redisService.setContains("followedAuthors", authorDid)).isTrue
+        verifyApiPost("/com.atproto.repo.createRecord", token, mapOf("record.subject" to authorDid))
+    }
+
+    @Test
+    fun `should fetch profile from API and store in Redis`() {
+        // Arrange
+        val did = "did:example:123"
+        val token = "test-access-token"
+        val expectedProfile = createTestProfile(did)
+        stubApiGet("/profile/$did", token, expectedProfile)
+
+        val userService = createUserService()
+        val redisService = createRedisService()
+
+        // Act
+        val actualProfile = userService.getProfile(token, did)
+
+        // Assert
+        verifyProfile(actualProfile, expectedProfile)
+        verifyProfileInRedis(redisService, did, expectedProfile)
+        verifyApiGet("/profile/$did", token)
+    }
+
+    @Test
+    fun `should fetch profile from Redis cache when available`() {
+        // Arrange
+        val did = "did:example:123"
+        val expectedProfile = createTestProfile(did, handle = "cached-handle", displayName = "Cached User")
+        val redisService = createRedisService()
+        cacheProfileInRedis(redisService, did, expectedProfile)
+
+        val userService = createUserService()
+
+        // Act
+        val actualProfile = userService.getProfile("unused-token", did)
+
+        // Assert
+        verifyProfile(actualProfile, expectedProfile)
+        verifyNoApiCall("/profile/$did")
+    }
+
+    // Helper Functions
+    private fun createTestProfile(
+        did: String,
+        handle: String = "test-handle",
+        displayName: String = "Test User",
+        description: String = "Test Description"
+    ): Profile {
+        return Profile(
+            did = did,
+            handle = handle,
+            displayName = displayName,
+            description = description,
+            avatar = "https://example.com/avatar.png",
+            banner = "https://example.com/banner.png",
+            followersCount = 100,
+            followsCount = 50,
+            postsCount = 10,
+            associated = Profile.Associated(
+                lists = 0, feedgens = 1, starterPacks = 2, labeler = true,
+                chat = Profile.Associated.Chat(allowIncoming = "all")
+            ),
+            joinedViaStarterPack = null,
+            indexedAt = "2024-11-07T00:27:25.289Z",
+            createdAt = "2024-11-01T00:00:00.000Z",
+            viewer = Profile.Viewer(
+                muted = false, mutedByList = null, blockedBy = false,
+                blocking = null, blockingByList = null, following = null,
+                followedBy = null, knownFollowers = null
+            ),
+            labels = emptyList(),
+            pinnedPost = null
+        )
+    }
+
+    private fun stubApiPost(endpoint: String, responseBody: Any) {
+        wireMockServer.stubFor(
+            post(urlPathEqualTo(endpoint))
+                .willReturn(aResponse().withStatus(200).withBody(Jackson.asFormatString(responseBody)))
+        )
+    }
+
+    private fun stubApiGet(endpoint: String, token: String, responseBody: Any) {
+        wireMockServer.stubFor(
+            get(urlPathEqualTo(endpoint))
+                .withHeader("Authorization", equalTo("Bearer $token"))
+                .willReturn(aResponse().withStatus(200).withBody(Jackson.asFormatString(responseBody)))
+        )
+    }
+
+    private fun cacheProfileInRedis(redisService: RedisService, did: String, profile: Profile) {
+        redisService.setJson("profile:$did", profile)
+    }
+
+    private fun verifyProfile(actual: Profile, expected: Profile) {
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+    }
+
+    private fun verifyProfileInRedis(redisService: RedisService, did: String, expected: Profile) {
+        val cachedProfile = redisService.getJsonAs<Profile>("profile:$did")
+        assertThat(cachedProfile).isNotNull
+        assertThat(Jackson.asFormatString(cachedProfile!!)).isEqualTo(Jackson.asFormatString(expected))
+    }
+
+    private fun verifyApiPost(endpoint: String, token: String, bodyChecks: Map<String, String>) {
+        val verifier = postRequestedFor(urlPathEqualTo(endpoint))
+            .withHeader("Authorization", equalTo("Bearer $token"))
+        bodyChecks.forEach { (path, value) -> verifier.withRequestBody(matchingJsonPath("\$.$path", equalTo(value))) }
+        wireMockServer.verify(verifier)
+    }
+
+    private fun verifyApiGet(endpoint: String, token: String) {
+        wireMockServer.verify(
+            getRequestedFor(urlPathEqualTo(endpoint))
+                .withHeader("Authorization", equalTo("Bearer $token"))
+        )
+    }
+
+    private fun verifyNoApiCall(endpoint: String) {
+        wireMockServer.verify(0, getRequestedFor(urlPathEqualTo(endpoint)))
+    }
+}


### PR DESCRIPTION
- Split BlueskyService into dedicated services: UserService, PostService, and AuthenticationService
- When a user is followed, it's now fully stored in Redis as well. All the information is kept for further analysis
- A Migration Service has been added to store previously followed users that haven't been added to Redis
- Replace JedisPool with JedisPooled in RedisService to ensure best practices