### PR TITLE
Add support to getProfiles to avoid multiple calls to Bsky API

### DIFF
--- a/src/main/kotlin/dev/raphaeldelio/model/Profiles.kt
+++ b/src/main/kotlin/dev/raphaeldelio/model/Profiles.kt
@@ -1,0 +1,5 @@
+package dev.raphaeldelio.model
+
+data class Profiles(
+    val profiles: List<Profile>
+)

--- a/src/main/kotlin/dev/raphaeldelio/service/MigrationService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/MigrationService.kt
@@ -36,9 +36,6 @@ class MigrationService(
     fun migrateUsers(token: String) {
         val followedAuthors = userService.getAllFollowedUsers()
         Logger.info("🚚 Migrating ${followedAuthors.size} followed authors")
-
-        followedAuthors.forEach { authorDid ->
-            userService.getProfile(token, authorDid)
-        }
+        userService.getProfiles(token, followedAuthors)
     }
 }

--- a/src/main/kotlin/dev/raphaeldelio/service/RedisService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/RedisService.kt
@@ -32,7 +32,7 @@ class RedisService(private val jedisPooled: JedisPooled) {
     }
 
     fun jsonGet(key: String): Any? {
-        return jedisPooled.jsonGet(key) ?: return null
+        return jedisPooled.jsonGet(key)
     }
 
     inline fun <reified T: Any> jsonGetAs(key: String): T? {

--- a/src/main/kotlin/dev/raphaeldelio/service/UserService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/UserService.kt
@@ -35,19 +35,39 @@ class UserService(
         )
     }
 
-    fun getProfile(token: String, did: String): Profile {
-        val key = "profile:$did"
+    fun getProfiles(token: String, authorDids: Set<String>): List<Profile> {
+        Logger.info("🔍 Fetching profiles for ${authorDids.size} authors")
+        authorDids.filter { !isProfileAlreadyStored(it) }.chunked(25).forEach { chunk ->
+            fetchProfilesFromApi(token, chunk.toSet())?.profiles?.forEach {
+                storeProfile(it)
+            }
+            Logger.info("🕒 Waiting 1 sec before next call")
+            Thread.sleep(1000)
+        }
+        Logger.info("🔍 Retrieved profiles for ${authorDids.size} authors")
+        return authorDids.mapNotNull { redisService.jsonGetAs<Profile>("profile:$it") }
+    }
 
-        // Try fetching from Redis
-        return redisService.jsonGetAs<Profile>(key)?.also {
-            Logger.info("ℹ️ Profile for DID: $did retrieved from Redis")
-        } ?: run {
-            // Fetch from API if not stored
-            fetchProfileFromApi(token, did).also { profile ->
-                redisService.jsonSet(key, profile)
-                Logger.info("🗄️ Profile for DID: $did stored in Redis")
+    fun getProfile(token: String, did: String): Profile? {
+        Logger.info("🔍 Fetching profile for DID: $did")
+        return if (isProfileAlreadyStored(did)) {
+            redisService.jsonGetAs<Profile>("profile:$did")
+        } else {
+            fetchProfileFromApi(token, did).also {
+                storeProfile(it)
+                Logger.info("🔍 Retrieved profile for DID: $did")
             }
         }
+    }
+
+    fun isProfileAlreadyStored(did: String): Boolean {
+        return redisService.jsonGet("profile:$did") != null
+    }
+
+    fun storeProfile(profile: Profile) {
+        val key = "profile:${profile.did}"
+        redisService.jsonSet(key, profile)
+        Logger.info("🗄️ Profile for DID: ${profile.did} stored in Redis")
     }
 
     private fun fetchProfileFromApi(token: String, did: String): Profile {
@@ -61,6 +81,28 @@ class UserService(
 
         return Jackson.asA(response.bodyString(), Profile::class).also {
             Logger.info("✅ Successfully retrieved profile for DID: $did")
+        }
+    }
+
+    private fun fetchProfilesFromApi(token: String, dids: Set<String>): Profiles? {
+        if (dids.isEmpty()) {
+            return null
+        }
+
+        if (dids.size > 25) {
+            throw IllegalArgumentException("Cannot fetch more than 25 profiles at once")
+        }
+
+        var request = createGetRequest("$apiUrl/app.bsky.actor.getProfiles/", token)
+        dids.forEach { request = request.query("actors", it) }
+
+        val response = client(request)
+        if (response.status != Status.OK) {
+            handleError("Failed to retrieve profile for DID: $dids", response)
+        }
+
+        return Jackson.asA(response.bodyString(), Profiles::class).also {
+            Logger.info("✅ Successfully retrieved profiles for DID: $dids")
         }
     }
 


### PR DESCRIPTION
Fix to use getProfiles API instead of getProfile to fetch multiple profiles and avoid overhead on the Bluesky API and possible too many requests error. 