### PR TITLE
Bsky changed their API and rkey can no longer be empty in the request

### DIFF
--- a/src/main/kotlin/dev/raphaeldelio/model/FollowData.kt
+++ b/src/main/kotlin/dev/raphaeldelio/model/FollowData.kt
@@ -6,7 +6,7 @@ import java.time.Instant
 data class FollowData(
     @JsonProperty("repo") val repo: String,
     @JsonProperty("collection") val collection: String = "app.bsky.graph.follow", // Namespace for follows
-    @JsonProperty("rkey") val rkey: String? = "",
+    //@JsonProperty("rkey") val rkey: String? = null,
     @JsonProperty("validate") val validate: Boolean? = false,
     @JsonProperty("record") val record: FollowRecord
 )

--- a/src/main/kotlin/dev/raphaeldelio/model/RepostData.kt
+++ b/src/main/kotlin/dev/raphaeldelio/model/RepostData.kt
@@ -6,7 +6,7 @@ import java.time.Instant
 data class RepostData(
     @JsonProperty("repo") val repo: String,
     @JsonProperty("collection") val collection: String,
-    @JsonProperty("rkey") val rkey: String? = "", // Optional
+    //@JsonProperty("rkey") val rkey: String? = null, // Optional
     @JsonProperty("validate") val validate: Boolean? = false, // Optional
     @JsonProperty("record") val record: RepostRecord
 )

--- a/src/main/kotlin/dev/raphaeldelio/service/PostService.kt
+++ b/src/main/kotlin/dev/raphaeldelio/service/PostService.kt
@@ -3,10 +3,8 @@ package dev.raphaeldelio.service
 import dev.raphaeldelio.Logger
 import dev.raphaeldelio.model.*
 import org.http4k.client.ApacheClient
-import org.http4k.client.ApacheClient.invoke
 import org.http4k.core.Method
 import org.http4k.core.Request
-import org.http4k.core.Request.Companion.invoke
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.format.Jackson
@@ -89,7 +87,6 @@ class PostService(
         return RepostData(
             repo = redisService.stringGet("did") ?: throw IllegalArgumentException("DID not found in Redis"),
             collection = collection,
-            rkey = "",
             validate = false,
             record = RepostRecord(
                 subject = Subject(


### PR DESCRIPTION
Two days ago the bot started failing with the following error:

```
{
    "error": "InvalidRequest",
    "message": "Input/rkey must be a string"
}
```

Turns out Bluesky changed the way they're processing their requests and the rkey field of requests can no longer be empty. 

Omitting the field altogether from the requests solved the issue. 